### PR TITLE
Removed the recursive call to Request.process() which caused stack overflows

### DIFF
--- a/src/commands/io/mod.rs
+++ b/src/commands/io/mod.rs
@@ -95,7 +95,7 @@ impl<A: IntoArg + std::fmt::Debug> Run<A> for Client {
         // need first class support for Tokio to get rid of this.
         let _ = ::std::thread::Builder::new()
             .name("submit".into())
-            .stack_size(78048)
+            //.stack_size(78048)
             .spawn(move || {
             let req = Request {
                 term: cterm,

--- a/src/commands/io/mod.rs
+++ b/src/commands/io/mod.rs
@@ -4,21 +4,20 @@ mod handshake;
 
 use crate::{
     Client, InnerConfig, Config, Connection, Document, IntoArg,
-    Arg, Opts, DEFAULT_PORT, Request, Response, Result, Run,
+    Opts, DEFAULT_PORT, Request, Response, Result, Run,
     Server, Session, SessionManager,
     errors::*,
 };
 use r2d2;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use futures::{Async, Poll, Future, Stream};
+use futures::{Async, Poll, Stream};
 use futures::sync::mpsc;
 use indexmap::IndexMap;
 use parking_lot::RwLock;
 use protobuf::ProtobufEnum;
 use ql2::proto::Query_QueryType as QueryType;
-use reql_types::{Change, ServerStatus};
 use serde::de::DeserializeOwned;
-use std::{error, thread};
+use std::{error};
 use std::cmp::Ordering;
 use std::io::{self, Read, Write};
 use std::net::SocketAddr;
@@ -57,8 +56,8 @@ pub fn connect<'a>(client: &Client, cfg: Config<'a>) -> Result<Connection> {
     Ok(conn)
 }
 
-impl<A: IntoArg> Run<A> for Client {
-    fn run<T: DeserializeOwned + Send + 'static>(&self, args: A) -> Result<Response<T>> {
+impl<A: IntoArg + std::fmt::Debug> Run<A> for Client {
+    fn run<T: DeserializeOwned + Send + std::fmt::Debug + 'static>(&self, args: A) -> Result<Response<T>> {
         let cterm = match self.term {
             Ok(ref term) => term.clone(),
             Err(ref error) => {
@@ -92,7 +91,10 @@ impl<A: IntoArg> Run<A> for Client {
         let (tx, rx) = mpsc::channel(CHANNEL_SIZE);
         // @TODO spawning a thread per query is less than ideal. Ideally we will
         // need first class support for Tokio to get rid of this.
-        ::std::thread::spawn(move || {
+        let _ = ::std::thread::Builder::new()
+            .name("submit".into())
+            //.stack_size(78048)
+            .spawn(move || {
             let req = Request {
                 term: cterm,
                 opts: aterm,
@@ -111,7 +113,7 @@ impl<A: IntoArg> Run<A> for Client {
     }
 }
 
-impl<T: DeserializeOwned + Send> Stream for Response<T> {
+impl<T: DeserializeOwned + Send + std::fmt::Debug> Stream for Response<T> {
     type Item = Option<Document<T>>;
     type Error = Error;
 
@@ -218,64 +220,6 @@ impl Connection {
         Ok(())
     }
 
-    fn maintain(&self) {
-        self.reset_cluster();
-        let conn = *self;
-        let (tx, rx) = ::std::sync::mpsc::sync_channel::<()>(CHANNEL_SIZE);
-        thread::spawn(move || {
-            let r = Client::new();
-            let mut args = Arg::new();
-            args.set_string("{include_initial: true}");
-            let tp = Arg::create_term_pair("include_initial", true).unwrap();
-            args.add_opt(tp);
-            let query = r.db("rethinkdb")
-                .table("server_status")
-                .changes()
-                .with_args(args);
-            let mut send = true;
-            loop {
-                let changes = query
-                    .run::<Change<ServerStatus, ServerStatus>>(conn)
-                    .unwrap();
-                let future = changes.for_each(|change| {
-                    if let Some(Document::Expected(change)) = change {
-                        if let Some(ref mut config) = CONFIG.write().get_mut(&conn) {
-                            let cluster = &mut config.cluster;
-                            if let Some(status) = change.new_val {
-                                let mut addresses = Vec::new();
-                                for addr in status.network.canonical_addresses {
-                                    let socket = SocketAddr::new(addr.host,
-                                                                 status.network.reql_port);
-                                    addresses.push(socket);
-                                }
-                                let mut server = Server::new(&status.name, addresses);
-                                server.set_latency();
-                                cluster.insert(server.name.to_owned(), server);
-                                if send {
-                                    if let Ok(_) = tx.send(()) {
-                                        send = false;
-                                    }
-                                }
-                            } else if let Some(status) = change.old_val {
-                                cluster.remove(&status.name);
-                            }
-                        }
-                    }
-                    Ok(())
-                });
-                let _ = future.wait();
-                thread::sleep(Duration::from_millis(500));
-            }
-        });
-        // wait for at least one database result before continuing
-        let _ = rx.recv();
-    }
-
-    fn reset_cluster(&self) {
-        if let Some(ref mut config) = CONFIG.write().get_mut(self) {
-            config.cluster = IndexMap::new();
-        }
-    }
 
     fn set_latency(&self) -> Result<()> {
         match CONFIG.write().get_mut(self) {
@@ -363,6 +307,7 @@ fn read_query(conn: &mut Session) -> Result<Vec<u8>> {
         conn.broken = true;
         return Err(io_error(error))?;
     }
+
     Ok(resp)
 }
 

--- a/src/commands/io/request.rs
+++ b/src/commands/io/request.rs
@@ -110,7 +110,7 @@ impl<T: DeserializeOwned + Send + std::fmt::Debug> Request<T> {
                             i += 1;
                             //continue;
                             more = false;
-                            //break;
+                            break;
                         },
                         Ok(true) => { // Continue processing, for example in changefeeds
                             query = wrap_query(QueryType::CONTINUE, None, None);
@@ -125,11 +125,13 @@ impl<T: DeserializeOwned + Send + std::fmt::Debug> Request<T> {
                         },
                         _ => {
                             more = false;
-                            //break;
+                            break;
                         }, // Otherwise we are done processing, time to end
                     }
                 }
-                //break;
+                if !more {
+                    break;
+                }
             }
         }
     }

--- a/src/commands/io/request.rs
+++ b/src/commands/io/request.rs
@@ -29,7 +29,7 @@ impl<T: DeserializeOwned + Send + std::fmt::Debug> Request<T> {
         let mut conn = match self.conn() {
             Ok(conn) => conn,
             Err(error) => {
-                let _ = self.tx.clone().send(Err(error));
+                let _ = self.tx.clone().send(Err(error)).wait();
                 return;
             }
         };
@@ -49,7 +49,7 @@ impl<T: DeserializeOwned + Send + std::fmt::Debug> Request<T> {
                         Ok(c) => c,
                         Err(error) => {
                             if i == self.cfg.opts.retries - 1 {
-                                let _ = self.tx.clone().send(Err(error.into()));
+                                let _ = self.tx.clone().send(Err(error.into())).wait();
                                 if !reproducible {
                                     return;
                                 }
@@ -82,7 +82,7 @@ impl<T: DeserializeOwned + Send + std::fmt::Debug> Request<T> {
                     if let Err(error) = write_query(&mut conn, &query) {
                         connect = true;
                         if i == self.cfg.opts.retries - 1 {
-                            let _ = self.tx.clone().send(Err(error.into()));
+                            let _ = self.tx.clone().send(Err(error.into())).wait();
                             if !reproducible {
                                 return;
                             }
@@ -102,7 +102,7 @@ impl<T: DeserializeOwned + Send + std::fmt::Debug> Request<T> {
                     match self.process(&mut conn) {
                         Err(error) => {
                             if i == self.cfg.opts.retries - 1 || !self.retry {
-                                let _ = self.tx.clone().send(Err(error.into()));
+                                let _ = self.tx.clone().send(Err(error.into())).wait();
                                 if !reproducible {
                                     return;
                                 }
@@ -117,7 +117,7 @@ impl<T: DeserializeOwned + Send + std::fmt::Debug> Request<T> {
                             if let Err(error) = write_query(&mut conn, &mut query) {
                                 self.write = true;
                                 self.retry = true;
-                                let _ = self.tx.clone().send(Err(error.into()));
+                                let _ = self.tx.clone().send(Err(error.into())).wait();
                                 continue
                                 //return Err(error)?;
                             }

--- a/src/commands/io/request.rs
+++ b/src/commands/io/request.rs
@@ -14,7 +14,7 @@ use serde_json::{Value, from_slice, from_value};
 use std::error::Error as StdError;
 use futures::{Future, Sink};
 
-impl<T: DeserializeOwned + Send> Request<T> {
+impl<T: DeserializeOwned + Send + std::fmt::Debug> Request<T> {
     fn conn(&self) -> Result<PooledConnection<SessionManager>> {
         match self.pool.get() {
             Ok(mut conn) => {
@@ -49,7 +49,7 @@ impl<T: DeserializeOwned + Send> Request<T> {
                         Ok(c) => c,
                         Err(error) => {
                             if i == self.cfg.opts.retries - 1 {
-                                let _ = self.tx.clone().send(Err(error.into())).wait();
+                                let _ = self.tx.clone().send(Err(error.into()));
                                 if !reproducible {
                                     return;
                                 }
@@ -163,6 +163,7 @@ impl<T: DeserializeOwned + Send> Request<T> {
                 }
                 // If the database says this response is an error convert the error
                 // message to our native one.
+                println!("size {:?}", self);
                 let has_generic_error = match respt {
                     ResponseType::CLIENT_ERROR |
                     ResponseType::COMPILE_ERROR |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@ pub struct Response<T: DeserializeOwned + Send> {
     rx: Receiver<Result<Option<Document<T>>>>,
 }
 
-struct Request<T: DeserializeOwned + Send> {
+#[derive(Debug)]
+struct Request< T: DeserializeOwned + Send + std::fmt::Debug> {
     term: Term,
     opts: Term,
     pool: r2d2::Pool<SessionManager>,
@@ -77,7 +78,7 @@ pub struct Config<'a> {
     pub tls: Option<TlsConnectorBuilder>,
 }
 
-#[derive(Clone)]
+#[derive(Debug,Clone)]
 struct InnerConfig {
     cluster: IndexMap<String, Server>,
     opts: Opts,
@@ -149,7 +150,7 @@ pub trait IntoArg {
 /// Lazily execute a command
 pub trait Run<A: IntoArg> {
     /// Prepare a commmand to be submitted
-    fn run<T: DeserializeOwned + Send + 'static>(&self, args: A) -> Result<Response<T>>;
+    fn run<T: DeserializeOwned + Send + std::fmt::Debug + 'static>(&self, args: A) -> Result<Response<T>>;
 }
 
 macro with_args($cmd: ident, $args: ident) {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,16 +169,3 @@ macro with_args($cmd: ident, $args: ident) {{
         }
     }
 }}
-
-
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    //Just perform some basic integration tests against a server
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 
 use uuid::Uuid;
 use futures::sync::mpsc::{Sender, Receiver};
+//use std::sync::mpsc::{Sender, Receiver};
 use serde_derive::{Serialize, Deserialize};
 
 /// Default ReQL port
@@ -168,3 +169,16 @@ macro with_args($cmd: ident, $args: ident) {{
         }
     }
 }}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    //Just perform some basic integration tests against a server
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -128,7 +128,7 @@ impl Encode for Datum {
     }
 }
 
-impl<T: DeserializeOwned + Send> Request<T> {
+impl<T: DeserializeOwned + Send + std::fmt::Debug> Request<T> {
     pub fn encode(&mut self, data: &Term, encoding_opts: bool) -> String {
         let mut res = Vec::new();
         if !data.is_datum() {


### PR DESCRIPTION
Stack overflow would occur when using changefeeds, which are kind of the best feature with 